### PR TITLE
#166858837 (feat): Admin can specify difficulty level for a SPEC

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+#### What does this PR do?
+
+
+#### Description of Task to be completed
+
+
+#### How should this be manually tested?
+
+
+#### Any background context you want to provide?
+
+
+#### What are the relevant pivotal tracker stories?
+[#]()
+
+#### Screenshots (if appropriate)

--- a/src/dash/css/main.scss
+++ b/src/dash/css/main.scss
@@ -136,6 +136,10 @@ body[data-nav=specs] .mdc-card.text-only .mdc-card__primary-action {
   padding: 1rem;
   min-height: 157px;
 }
+
+.width-class {
+  max-width: 65%;
+}
 /* End Specs */
 
 /* Assesstemts */

--- a/src/dash/index.html
+++ b/src/dash/index.html
@@ -141,6 +141,26 @@
               </div>
             </p>
 
+            <div id="specdifficulty-field" class="mdc-select mdc-select--outlined width-class" >
+              <input type="hidden" name="enhanced-select">
+              <i class="mdc-select__dropdown-icon"></i>
+              <div class="mdc-select__selected-text"></div>
+              <div class="mdc-select__menu mdc-menu mdc-menu-surface width-class">
+                <ul class="specdifficulty-ul mdc-list">
+                  <li class="mdc-list-item" data-value="beginner">Beginner (Default)</li>
+                  <li class="mdc-list-item" data-value="intermediate">Intermediate</li>
+                  <li class="mdc-list-item" data-value="advanced">Advanced</li>
+                </ul>
+              </div>
+              <div class="mdc-notched-outline">
+                <div class="mdc-notched-outline__leading"></div>
+                <div class="mdc-notched-outline__notch">
+                  <label class="mdc-floating-label mdc-floating-label--float-above">Difficulty Level</label>
+                </div>
+                <div class="mdc-notched-outline__trailing"></div>
+              </div>
+            </div>
+
             <p>
               <button data-action="add-challenge" class="mdc-button">
                 <span class="material-icons">

--- a/src/dash/js/specs.js
+++ b/src/dash/js/specs.js
@@ -105,6 +105,10 @@ const clearInputValues = () => {
   render(challengeListItemTPL([]), challengeListEl);
 
   select(".mdc-select__selected-text").innerHTML="";
+  const instructionsTemplate = select("[data-manage-challenge-instructions]");
+  if (instructionsTemplate) {
+    instructionsTemplate.setAttribute('data-details-item', 'off');
+  };
 
   [
     select("#specname-field input"),

--- a/src/dash/js/specs.js
+++ b/src/dash/js/specs.js
@@ -27,6 +27,7 @@ const specsListEl = select("#specs-list");
 const saveSpecBtn = select(`[data-action='save-spec']`);
 const specNameField = select("#specname-field");
 const specAboutField = select("#specabout-field");
+const specDifficultyField = select("#specdifficulty-field")
 const challengeListEl = select("#challenge-list");
 
 const switchDetailsTo = attr => {
@@ -85,6 +86,7 @@ const extriesAreValid = () =>
   spec &&
   trim(spec.name) !== "" &&
   trim(spec.about) !== "" &&
+  spec.difficulty !== undefined &&
   Array.isArray(spec.challenges);
 
 const canSaveSpec = () => {
@@ -101,6 +103,8 @@ const clearInputValues = () => {
   spec = {};
   if(instructionsEditor) instructionsEditor.setValue("");
   render(challengeListItemTPL([]), challengeListEl);
+
+  select(".mdc-select__selected-text").innerHTML="";
 
   [
     select("#specname-field input"),
@@ -141,6 +145,11 @@ const specNameChanged = event => {
 
 const specAboutChanged = event => {
   spec.about = event.target.value;
+};
+
+const specDifficultyChanged = event => {
+  const target = event.currentTarget.querySelector('input');
+  spec.difficulty = target.value;
 };
 
 const addAChallenge = () => {
@@ -236,6 +245,10 @@ const buildUI = mode => {
     .querySelector("input")
     .addEventListener("blur", specAboutChanged);
 
+  mdc.select.MDCSelect.attachTo(specDifficultyField);
+  specDifficultyField
+    .addEventListener("MDCSelect:change", specDifficultyChanged);
+
   mdc.list.MDCList.attachTo(challengeListEl);
   const challengeList = new mdc.list.MDCList.attachTo(challengeListEl);
   challengeList.singleSelection = true;
@@ -312,6 +325,24 @@ const adminWillCreateSpec = () => {
   rAF().then(queue => queue(canSaveSpec));
 };
 
+const manageDifficultySelection = (difficulty) => {
+  const selectedTextNodes = [...selectAll(".specdifficulty-ul .mdc-list-item--selected")];
+  const difficultyInput = specDifficultyField.querySelector("input");
+  const difficultyOption = select(`[data-value=${difficulty}]`);
+  const selectedText = specDifficultyField.querySelector(".mdc-select__selected-text");
+
+  selectedTextNodes
+  .map(
+    node => node.classList.remove('mdc-list-item--selected')
+  );
+
+  difficultyInput.value = difficulty;
+  difficultyOption.classList.add('mdc-list-item--selected');
+  difficultyOption.setAttribute('aria-selected', 'true');
+  selectedText.innerHTML = `${difficulty.charAt(0).toUpperCase()}${difficulty.slice(1)}`;
+  selectedText.focus()
+}
+
 const manageASpec = event => {
   const itemEl = event.target.closest(".mdc-card");
   if (!itemEl) return;
@@ -334,6 +365,10 @@ const manageASpec = event => {
       const aboutInput = specAboutField.querySelector("input");
       aboutInput.value = spec.about || '';
       aboutInput.focus();
+
+      let difficulty = "beginner";
+      if (spec.difficulty) ({ difficulty } = spec);
+      manageDifficultySelection(difficulty);
 
       render(challengeListItemTPL(spec.challenges), challengeListEl);
       challengeListEl.querySelector("li").click();


### PR DESCRIPTION
#### What does this PR do?
- adds a spec difficulty field to specs
- fixes bug that shows challenge instructions when creating a new spec
- adds a PR template

#### Description of Task to be completed
Admins are not able to tell the extent of competencies that candidates have, given that all SPECs currently assume a beginner level of difficulty

Difficulty levels should include
* Beginner
* Intermediate
* Advanced

#### How should this be manually tested?
- fetch from this repo and switch to the branch `ft-difficulty-level-166858837`
- start the server using `yarn develop-admin`
- create a new spec or view an existing spec, you should see the difficulty level

#### Any background context you want to provide?
- If a spec hasn't been assigned a difficulty level, the default level shown is Beginner

#### What are the relevant pivotal tracker stories?
[#16685883 Admin can specify difficulty level for a SPEC](https://www.pivotaltracker.com/story/show/166858837)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/28973383/60245459-f00a6f00-98bc-11e9-95f5-390c2bd51e3e.png)
![image](https://user-images.githubusercontent.com/28973383/60245466-f3055f80-98bc-11e9-9a16-3d8abb4b9227.png)
