### PR TITLE
#166910639 add candidate's user photo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ node_modules/
 # parcel
 .cache/
 dev-build/
+
+#vscode
+.vscode

--- a/src/playground/css/main.scss
+++ b/src/playground/css/main.scss
@@ -167,6 +167,14 @@ body[data-assessment] header.mdc-top-app-bar--short-collapsed button {
   min-height: 100%;
 }
 
+.mdc-icon-button img {
+  position: fixed;
+  width: 50px;
+  height: 50px;
+  top: 0.2em;
+  right: 1em;
+}
+
 /* Style The Challenge Instructions */
 
 #instructions [data-task-title] {

--- a/src/playground/css/main.scss
+++ b/src/playground/css/main.scss
@@ -173,6 +173,7 @@ body[data-assessment] header.mdc-top-app-bar--short-collapsed button {
   height: 50px;
   top: 0.2em;
   right: 1em;
+  border-radius: 50%;
 }
 
 /* Style The Challenge Instructions */
@@ -293,6 +294,7 @@ body[data-nav='playground'] [data-profile] {
   position: fixed;
   top: 0.2em;
   right: 1em;
+  border-radius: 50%;
 }
 
 body[data-nav='playground'] [data-timer] {

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -162,7 +162,7 @@
       </div>
 
       <div data-timer>Deadline: <span></span></div>
-      <button data-profile class="mdc-icon-button material-icons">
+      <button data-profile id="photo" class="mdc-icon-button material-icons">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
           <path
             d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z" />

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -162,7 +162,7 @@
       </div>
 
       <div data-timer>Deadline: <span></span></div>
-      <button data-profile id="photo" class="mdc-icon-button material-icons">
+      <button data-profile id="photo" class="mdc-icon-button material-icons mdc-elevation--z3">
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
           <path
             d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z" />

--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -60,13 +60,12 @@ const signOut = event => {
 };
 
 const setupAccount = () => {
-  console.log(appUser.photoURL);
-  const img = document.createElement("img");
-  img.src = appUser.photoURL;
-  const src = document.getElementById("photo");
-  
-  src.appendChild(img);
-  
+  if(appUser.photoURL) {
+    const img = document.createElement("img");
+    img.src = appUser.photoURL;
+    const src = document.getElementById("photo");
+    src.appendChild(img);
+  }
   const userIconBtn = select('button[data-profile]');
   const usrMenu = mdc.menu.MDCMenu.attachTo(select('.mdc-menu'));
   userIconBtn.addEventListener('click', event => {

--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -60,6 +60,13 @@ const signOut = event => {
 };
 
 const setupAccount = () => {
+  console.log(appUser.photoURL);
+  const img = document.createElement("img");
+  img.src = appUser.photoURL;
+  const src = document.getElementById("photo");
+  
+  src.appendChild(img);
+  
   const userIconBtn = select('button[data-profile]');
   const usrMenu = mdc.menu.MDCMenu.attachTo(select('.mdc-menu'));
   userIconBtn.addEventListener('click', event => {


### PR DESCRIPTION
**What does this PR do?**

- adds a candidate's profile image 

**Description of Task to be completed**
Candidates taking assessments have a poor user experience because 
they cannot quickly identify and verify their identity with any visual element on the platform.
This task adds an identifier for their accounts.
**How should this be manually tested?**
- fetch from this repo and switch to the branch ft-difficulty-level-166910639
- start the server using yarn develop-playground
- View your profile image in the top right

**Any background context you want to provide?**
None
**What are the relevant pivotal tracker stories?**
[#166910639](https://www.pivotaltracker.com/story/show/166910639)
**Screenshots (if appropriate)**
<img width="1440" alt="photo" src="https://user-images.githubusercontent.com/9946845/60250568-31a01780-98c7-11e9-8578-0801adaefb9f.png">
