### PR TITLE
#166910983 Correctly flag dropped out candidates

### DIFF
--- a/src/dash/js/assessments.js
+++ b/src/dash/js/assessments.js
@@ -21,6 +21,7 @@ let chart;
 let builtUI = false;
 let assessment = {};
 let candidates = [];
+let candidatesStatus = 'Completed NONE';
 
 let monitoringCanSaveTest = false;
 
@@ -40,9 +41,22 @@ const getAssessmentPublicKey = () =>
     .reverse()
     .join('');
 
+/**
+ * @description this checks whether an assessment is ongoing or not
+ * and sets the value of the global variable called "candidatesStatus"
+ * 
+ * @param { object } theAssessment
+ */
+const droppedOutOrCompletedNone = (theAssessment) => {
+  if (theAssessment && theAssessment.endingAt) {
+    const secondsToGo = Date.parse(theAssessment.endingAt) - Date.parse(new Date());
+    candidatesStatus = secondsToGo < 0 ? "Dropped Out" : "Completed NONE";
+  }
+};
+    
 const setAssessmentObject = (obj = {}) => {
+  droppedOutOrCompletedNone(obj);
   assessment = obj;
-
   if (obj.id) {
     extractTestIDBtn.removeAttribute('disabled');
   } else {
@@ -125,8 +139,7 @@ const doesAssessmentHaveSubmissions = () =>
   });
 
 const extriesAreValid = () => {
-  const { name, cycle, startingAt, endingAt } = assessment;
-
+  const { name, slug, cycle, startingAt, endingAt } = assessment;
   return (
     trim(name) !== '' &&
     trim(cycle) !== '' &&
@@ -271,8 +284,8 @@ const getChartDataTPL = () => ({
       'Completed Challenge 3',
       'Completed Challenge 2',
       'Completed Challenge 1',
-      'Dropped Out',
-      "Didn't Start"
+      candidatesStatus,
+      'Didn\'t Start'
     ],
     datasets: [
       {
@@ -309,7 +322,7 @@ const initChart = () => {
               color: 'grey'
             },
             {
-              text: 'Candidtates',
+              text: 'Candidates',
               font: {
                 size: '50'
               }
@@ -618,7 +631,6 @@ const manageATest = event => {
 
   buildUI({ mode: 'manage' });
   clearInputValues();
-  resetDataAndChart();
 
   ASSESSMENTS.doc(id)
     .get()
@@ -627,6 +639,7 @@ const manageATest = event => {
         id: doc.id,
         ...doc.data()
       });
+      resetDataAndChart();
 
       [
         select('#testname-io'),


### PR DESCRIPTION
#### What does this PR do?
Correctly flag `Dropped out` candidates when the assessment has ended. And flag candidates who had `Completed None` when the assessment is still ongoing.

#### Description of Task to be completed
- add a function that checks dropped out or completed none
- reposition the resetdataandchart function in the manageatest function

#### How should this be manually tested?
- Switch to the branch `ft-correctly-flag-drop-outs-or-not-166910983`
- start the server using `yarn develop-admin`
- View a challenge

#### Any background context you want to provide?
- Admins and stakeholders are not able to correctly tell when candidates have "Dropped Out" from an assessment or has "Completed None" of the assessment 

#### What are the relevant pivotal tracker stories?
[#166910983 Correctly flag dropped out candidates](https://www.pivotaltracker.com/story/show/166910983)

#### Screenshots (if appropriate)
**Completed NONE**
<img width="1440" alt="Screenshot 2019-06-28 at 10 14 50 AM" src="https://user-images.githubusercontent.com/31534129/60328499-ac803580-998e-11e9-80d7-d4593f1793f7.png">

**Dropped Out**
<img width="1440" alt="Screenshot 2019-06-28 at 10 15 06 AM" src="https://user-images.githubusercontent.com/31534129/60328533-b99d2480-998e-11e9-8b8b-5c993b237c4b.png">
