### PR TITLE
#166682093 Proper Sign out Menu Positioning

### DIFF
--- a/src/playground/css/main.scss
+++ b/src/playground/css/main.scss
@@ -207,7 +207,7 @@ body[data-assessment] #instructions [data-challenge-info-wrap] {
 #viewer {
   position: absolute;
   top: 65px;
-  left: 50%;
+  left: 40%;
   opacity: 0;
   height: 878px;
   width: 523px;
@@ -316,5 +316,13 @@ body[data-nav='playground'] #launcher-svg-container.km-chat-icon-sidebox {
 body[data-nav='playground'] #launcher-svg-container.km-chat-icon-sidebox img {
   width: 70%;
 }
-
+.mdc-menu .mdc-list {
+  padding-bottom: 0px;
+  padding-top: 0px;
+}
+.signout-btn {
+  left: 93% !important;
+  top: 60px !important;
+  min-width: 90px;
+}
 /* End Playground */

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -169,7 +169,7 @@
           <path d="M0 0h24v24H0z" fill="none" />
         </svg>
       </button>
-      <div class="mdc-menu mdc-menu-surface" tabindex="-1">
+      <div class="mdc-menu mdc-menu-surface signout-btn" tabindex="-1">
         <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical">
           <li class="mdc-list-item" role="menuitem" id="signout">
             <span class="mdc-list-item__text">Signout</span>

--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -64,7 +64,9 @@ const setupAccount = () => {
   const usrMenu = mdc.menu.MDCMenu.attachTo(select('.mdc-menu'));
   userIconBtn.addEventListener('click', event => {
     event.preventDefault();
-    usrMenu.open = true;
+    if (!usrMenu.open) {
+      usrMenu.open = true;
+    }
   });
   usrMenu.setFixedPosition(true);
   select('#signout').addEventListener('click', signOut);


### PR DESCRIPTION
### What does this PR do?
- Aligns the signout button to the right.
### Description of Task to be completed
Currently, the sign out button is aligned to the left and lacks padding with the top nav bar which creates a poor user experience. 
This feature properly aligns the sign out button to the top right side of the application's page (beneath the profile image).
### How should this be manually tested?
* Clone this repo: git clone https://github.com/andela/gradr
* Run `yarn install` to set up the dependencies.
* Checkout to this branch git checkout `ft-signout-positioning-166682093`
* Run `yarn develop-playground` to launch the user playground. 
* Click on the profile avatar to sign out, A sign out button will display beneath the avatar.
 ### What are the relevant pivotal tracker stories?
[#166682093](https://www.pivotaltracker.com/story/show/166682093)
### Screenshots.
<img width="1440" alt="Screenshot 2019-06-28 at 10 35 13" src="https://user-images.githubusercontent.com/32167860/60395979-b72bfd80-9b3b-11e9-8a33-1f89d73c7071.png">
