### PR TITLE
#166974572 add the delete spec feature

### DIFF
--- a/src/dash/index.html
+++ b/src/dash/index.html
@@ -113,7 +113,7 @@
               <button data-action="save-spec" class="mdc-button mdc-button--outlined pull-right">
                 <span class="mdc-button__label">Save Spec</span>
               </button>
-              <button data-action="delete-test" class="mdc-icon-button pull-right hide-element">
+              <button data-action="delete-spec" class="mdc-icon-button pull-right hide-element">
                 <i class="material-icons mdc-button__icon">
                   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
                     <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
@@ -133,7 +133,7 @@
                       Delete Spec
                   </h2>
                   <div class="mdc-dialog__content" id="my-dialog-content">
-                    Are you sure that you want to delete this spec?
+                    Are you sure you want to delete this Spec?
                   </div>
                   <footer class="mdc-dialog__actions">
                     <button type="button" class="mdc-button mdc-dialog__button mdc-ripple-upgraded mdc-ripple-upgraded--background-focused" data-mdc-dialog-action="close">

--- a/src/dash/index.html
+++ b/src/dash/index.html
@@ -113,7 +113,40 @@
               <button data-action="save-spec" class="mdc-button mdc-button--outlined pull-right">
                 <span class="mdc-button__label">Save Spec</span>
               </button>
+              <button data-action="delete-test" class="mdc-icon-button pull-right hide-element">
+                <i class="material-icons mdc-button__icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                    <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/>
+                    <path d="M0 0h24v24H0z" fill="none"/>
+                  </svg>
+                </i>
+              </button>
             </h5>
+              <div class="mdc-dialog" data-action="delete-dialog"
+                role="alertdialog"
+                aria-modal="true"
+                aria-labelledby="my-dialog-title"
+                aria-describedby="my-dialog-content">
+              <div class="mdc-dialog__container">
+                <div class="mdc-dialog__surface">
+                  <h2 class="mdc-dialog__title" id="my-dialog-title">
+                      Delete Spec
+                  </h2>
+                  <div class="mdc-dialog__content" id="my-dialog-content">
+                    Are you sure that you want to delete this spec?
+                  </div>
+                  <footer class="mdc-dialog__actions">
+                    <button type="button" class="mdc-button mdc-dialog__button mdc-ripple-upgraded mdc-ripple-upgraded--background-focused" data-mdc-dialog-action="close">
+                      <span class="mdc-button__label">Cancel</span>
+                    </button>
+                    <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="delete" data-action="delete-confirm">
+                      <span class="mdc-button__label">Delete Spec</span>
+                    </button>
+                  </footer>
+                </div>
+              </div>
+              <div class="mdc-dialog__scrim"></div>
+            </div>
           </div>
 
           <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-4">

--- a/src/dash/js/specs.js
+++ b/src/dash/js/specs.js
@@ -30,7 +30,7 @@ const specAboutField = select("#specabout-field");
 const specDifficultyField = select("#specdifficulty-field")
 const challengeListEl = select("#challenge-list");
 
-const deleteSpecIcon = select(`[data-action='delete-test']`);
+const deleteSpecIcon = select(`[data-action='delete-spec']`);
 const deleteConfirmBtn = select(`[data-action='delete-confirm']`);
 const deleteDialogComponent = select(`[data-action='delete-dialog']`);
 const cancelDeleteBtn = select(`[data-mdc-dialog-action='close']`);
@@ -38,12 +38,12 @@ const deleteDialogScrim = select('.mdc-dialog__scrim');
 
  const deleteSpec = () => {
   if (!spec || !spec.id) return;
-  SPECS.doc(spec.id)
-    .delete().then(() => {
-    console.log('Spec successfully deleted!');
+  SPECS.doc(spec.id).delete().then(() => {
+    // TODO notify user
     window.location.pathname = '!#specs';
   }).catch((error) => {
-    console.error('Error deleting spec: ', error);
+    // TODO notify user
+    console.warn('Error deleting spec: ', error.message);
   });
 }
 

--- a/src/dash/js/specs.js
+++ b/src/dash/js/specs.js
@@ -15,7 +15,7 @@ import {
   exceptId
 } from "../../commons/js/utils.js";
 
-let spec;
+let spec = {};
 let builtUI = false;
 let starterEditor;
 let instructionsEditor;
@@ -30,6 +30,37 @@ const specAboutField = select("#specabout-field");
 const specDifficultyField = select("#specdifficulty-field")
 const challengeListEl = select("#challenge-list");
 
+const deleteSpecIcon = select(`[data-action='delete-test']`);
+const deleteConfirmBtn = select(`[data-action='delete-confirm']`);
+const deleteDialogComponent = select(`[data-action='delete-dialog']`);
+const cancelDeleteBtn = select(`[data-mdc-dialog-action='close']`);
+const deleteDialogScrim = select('.mdc-dialog__scrim');
+
+ const deleteSpec = () => {
+  if (!spec || !spec.id) return;
+  SPECS.doc(spec.id)
+    .delete().then(() => {
+    console.log('Spec successfully deleted!');
+    window.location.pathname = '!#specs';
+  }).catch((error) => {
+    console.error('Error deleting spec: ', error);
+  });
+}
+
+ const closeDeleteDialog = () => {
+  deleteDialogComponent.classList.remove('mdc-dialog--open');
+  cancelDeleteBtn.removeEventListener('click', closeDeleteDialog);
+  deleteDialogScrim.removeEventListener('click', closeDeleteDialog);
+  deleteConfirmBtn.removeEventListener('click', deleteSpec);
+}
+
+ const openDeleteDialog = () => {
+  if (!spec || !spec.id) return;
+  deleteDialogComponent.classList.add('mdc-dialog--open');
+  cancelDeleteBtn.addEventListener('click', closeDeleteDialog);
+  deleteDialogScrim.addEventListener('click', closeDeleteDialog);
+  deleteConfirmBtn.addEventListener('click', deleteSpec);
+}
 const switchDetailsTo = attr => {
   const node = select(`[${attr}]`);
   if(!node) return;
@@ -287,6 +318,8 @@ const buildUI = mode => {
       };
     });
   });
+
+  deleteSpecIcon.addEventListener("click", openDeleteDialog);
 
   loadCodemirrorAssets({
     mode: "markdown"


### PR DESCRIPTION
#### What does this PR do?
- Adds the delete spec function in the spec.js file
- Adds the material design pop-up dialog 

#### Description of Task to be completed
Admins are not able to delete specs at the moment. This task adds the functionality to allow the admins to easily delete a spec.

#### How should this be manually tested?
* Switch to the branch ft-spec-assessment-166974572
* start the server using yarn develop-admin
* View the specs but DO NOT DELETE AN EXISTING SPEC, create a new SPEC and delete it.

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#166974572](https://www.pivotaltracker.com/story/show/166974572)

#### Screenshots (if appropriate)
![Screen Shot 2019-07-03 at 10 29 32 AM](https://user-images.githubusercontent.com/9946845/60576471-c3070200-9d7d-11e9-8edb-a6ddec2799aa.png)
