### PR TITLE
#167062571 fix card display of tests 

### DIFF
--- a/src/dash/css/main.scss
+++ b/src/dash/css/main.scss
@@ -292,4 +292,8 @@ body[data-nav=assessments] .mdc-card.text-only:hover {
   padding-left: -20px;
   margin-left: -40px;
 }
+.spec-card{
+  height: 100%
+}
+
 /* End Assesstemts */

--- a/src/dash/index.html
+++ b/src/dash/index.html
@@ -163,7 +163,7 @@
 
           <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-4">
             <div id="specname-field" class="mdc-text-field mdc-text-field--outlined">
-              <input type="text" id="specname-io" class="mdc-text-field__input" />
+              <input type="text" id="specname-io" class="mdc-text-field__input" maxlength="20" placeholder="Max: 20 characters"/>
               <div class="mdc-notched-outline">
                 <div class="mdc-notched-outline__leading"></div>
                 <div class="mdc-notched-outline__notch">
@@ -175,7 +175,7 @@
 
             <p>
               <div id="specabout-field" class="mdc-text-field mdc-text-field--outlined">
-                <input type="text" id="specabout-io" class="mdc-text-field__input" />
+                <input type="text" id="specabout-io" class="mdc-text-field__input" maxlength="50" placeholder="Max: 50 characters"/>
                 <div class="mdc-notched-outline">
                   <div class="mdc-notched-outline__leading"></div>
                   <div class="mdc-notched-outline__notch">
@@ -334,7 +334,7 @@
             <div class="mdc-layout-grid__inner">
               <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
                 <div id="testname-field" class="mdc-text-field mdc-text-field--outlined">
-                  <input type="text" id="testname-io" data-field="name" class="mdc-text-field__input" />
+                  <input type="text" id="testname-io" data-field="name" class="mdc-text-field__input" maxlength="30" placeholder="Max: 30 characters"/>
                   <div class="mdc-notched-outline">
                     <div class="mdc-notched-outline__leading"></div>
                     <div class="mdc-notched-outline__notch">
@@ -346,7 +346,7 @@
               </div>
               <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
                 <div id="testcycle-field" class="mdc-text-field mdc-text-field--outlined">
-                  <input type="text" id="testcycle-io" data-field="cycle" class="mdc-text-field__input" />
+                  <input type="text" id="testcycle-io" data-field="cycle" class="mdc-text-field__input" maxlength="20" placeholder="Max: 20 characters" />
                   <div class="mdc-notched-outline">
                     <div class="mdc-notched-outline__leading"></div>
                     <div class="mdc-notched-outline__notch">

--- a/src/dash/js/assessments.js
+++ b/src/dash/js/assessments.js
@@ -710,7 +710,7 @@ const testsListItemTPL = specs => html`
     item => html`
       <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-2">
         <div
-          class="mdc-card text-only"
+          class="mdc-card text-only spec-card"
           data-key=${item.id}
           @click=${manageATest}
         >


### PR DESCRIPTION
#### What does this PR do?
- Ensures cards are all the same height regardless of content
#### Description of Task to be completed
- add class to cards
- give card height of 100%

#### How should this be manually tested?
- switch to the branch `ft-display-assessment-listing-167062571`
- start the server using `yarn develop-admin`
- click on the tests icon to view all tests
-  all cards are the same size


#### Any background context you want to provide?
`N/A`

#### What are the relevant pivotal tracker stories?
[#167062571](https://www.pivotaltracker.com/story/show/167062571)

#### Screenshots (if appropriate)
<img width="1237" alt="Screenshot 2019-07-08 at 21 07 56" src="https://user-images.githubusercontent.com/31400129/60835990-d6bec800-a1c4-11e9-959c-bed67572fa9c.png">

<img width="1229" alt="Screenshot 2019-07-16 at 08 32 34" src="https://user-images.githubusercontent.com/31400129/61271243-5be94480-a7a4-11e9-83d2-a06758f638e2.png">
