### PR TITLE
#167062567 fix specs display listing 

### DIFF
--- a/src/dash/css/main.scss
+++ b/src/dash/css/main.scss
@@ -292,4 +292,8 @@ body[data-nav=assessments] .mdc-card.text-only:hover {
   padding-left: -20px;
   margin-left: -40px;
 }
+.spec-card{
+  height: 100%
+}
+
 /* End Assesstemts */

--- a/src/dash/js/assessments.js
+++ b/src/dash/js/assessments.js
@@ -710,7 +710,7 @@ const testsListItemTPL = specs => html`
     item => html`
       <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-2">
         <div
-          class="mdc-card text-only"
+          class="mdc-card text-only spec-card"
           data-key=${item.id}
           @click=${manageATest}
         >

--- a/src/dash/js/specs.js
+++ b/src/dash/js/specs.js
@@ -439,11 +439,11 @@ const specsListItemTPL = specs => {
       item => html`
         <div class="mdc-layout-grid__cell mdc-layout-grid__cell--span-2">
           <div
-            class="mdc-card text-only"
+            class="mdc-card text-only spec-card"
             data-key=${item.id}
             @click=${manageASpec}
           >
-            <div class="mdc-card__primary-action" tabindex="0">
+            <div class="mdc-card__primary-action spec-card" tabindex="0">
               <h2 class="mdc-typography--headline6">${item.name}</h2>
               <div class="mdc-typography--body2">${item.about}</div>
             </div>


### PR DESCRIPTION
#### What does this PR do?
- Fix the specs to have the same length when the length of the spec title is different
#### Description of Task to be completed
- Ensure all cards have the same width
#### How should this be manually tested?
- Switch to the branch ft-display-specs-listing-167062567`
- Start the server using yarn develop-admin
- Click on the specs icon to view all tests
- Add spec title of any length
- All cards are the same size
#### Any background context you want to provide?

`N/A`
#### What are the relevant pivotal tracker stories?
[#167062567](https://www.pivotaltracker.com/story/show/167062567)

#### Screenshots (if appropriate)
<img width="1254" alt="Screenshot 2019-07-15 at 13 27 36" src="https://user-images.githubusercontent.com/31400129/61213095-5a683f80-a704-11e9-8a45-2762286c2dd0.png">
