### PR TITLE
#167421868 Add feature that enables saving codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,10 @@
   "scripts": {
     "lint": "eslint src -c src/.eslintrc.json",
     "build-engines": "minify dist/playground/mygradr -d dist/playground/mygradr",
-
     "develop-playground": "parcel src/playground/index.html --out-dir dev-build",
     "develop-admin": "parcel src/dash/index.html --out-dir dev-build",
-
     "build-playground": "parcel build src/playground/index.html --out-dir dist/playground --no-source-maps",
     "build-admin": "parcel build src/dash/index.html --out-dir dist/admin --no-source-maps",
-
     "deploy-admin": "firebase deploy --only hosting:admin",
     "deploy-playground": "minify dist/playground/mygradr -d dist/playground/mygradr && firebase deploy --only hosting:playground"
   },
@@ -56,6 +53,7 @@
     "chartjs-plugin-datalabels": "^0.6.0",
     "chartjs-plugin-doughnutlabel": "^2.0.3",
     "codemirror": "^5.42.2",
+    "dotenv": "^8.0.0",
     "firebase": "^6.2.4",
     "first-input-delay": "^0.1.3",
     "g": "^2.0.1",

--- a/src/dash/index.html
+++ b/src/dash/index.html
@@ -139,11 +139,11 @@
                 </i>
               </button>
             </h5>
-              <div class="mdc-dialog" data-action="delete-dialog"
-                role="alertdialog"
-                aria-modal="true"
-                aria-labelledby="my-dialog-title"
-                aria-describedby="my-dialog-content">
+            <div class="mdc-dialog" data-action="delete-dialog"
+              role="alertdialog"
+              aria-modal="true"
+              aria-labelledby="my-dialog-title"
+              aria-describedby="my-dialog-content">
               <div class="mdc-dialog__container">
                 <div class="mdc-dialog__surface">
                   <h2 class="mdc-dialog__title" id="my-dialog-title">

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -28,7 +28,7 @@
   <script defer src="https://www.googletagmanager.com/gtag/js?id=UA-143248811-1"></script>
 </head>
 
-<body class="mdc-typography">
+<body class="mdc-typography" id="main-container">
   <header class="mdc-top-app-bar mdc-top-app-bar--short mdc-top-app-bar--short-collapsed">
     <div class="mdc-top-app-bar__row">
       <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
@@ -72,6 +72,31 @@
   </div>
 
   <main class="mdc-top-app-bar--fixed-adjust">
+    <div class="mdc-dialog" data-action="save-code-dialog"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="my-dialog-title"
+      aria-describedby="my-dialog-content">
+      <div class="mdc-dialog__container">
+        <div class="mdc-dialog__surface">
+          <h2 class="mdc-dialog__title" id="my-dialog-title">
+            Save Your Progress
+          </h2>
+          <div class="mdc-dialog__content" id="my-dialog-content">
+            Click the "Save Progress" button to save your progress in this challenge
+          </div>
+          <footer class="mdc-dialog__actions">
+            <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="close">
+              <span class="mdc-button__label">Cancel</span>
+            </button>
+            <button type="button" class="mdc-button mdc-dialog__button mdc-ripple-upgraded mdc-ripple-upgraded--background-focused" data-mdc-dialog-action="save-code">
+              <span class="mdc-button__label">Save Progress</span>
+            </button>
+          </footer>
+        </div>
+      </div>
+      <div class="mdc-dialog__scrim" id="save-code-scrim"></div>
+    </div>
     <div data-view="home">
       <div class="mdc-layout-grid">
         <div class="mdc-layout-grid__inner">

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -28,7 +28,7 @@
   <script defer src="https://www.googletagmanager.com/gtag/js?id=UA-143248811-1"></script>
 </head>
 
-<body class="mdc-typography" id="main-container">
+<body class="mdc-typography">
   <header class="mdc-top-app-bar mdc-top-app-bar--short mdc-top-app-bar--short-collapsed">
     <div class="mdc-top-app-bar__row">
       <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">
@@ -72,31 +72,6 @@
   </div>
 
   <main class="mdc-top-app-bar--fixed-adjust">
-    <div class="mdc-dialog" data-action="save-code-dialog"
-      role="alertdialog"
-      aria-modal="true"
-      aria-labelledby="my-dialog-title"
-      aria-describedby="my-dialog-content">
-      <div class="mdc-dialog__container">
-        <div class="mdc-dialog__surface">
-          <h2 class="mdc-dialog__title" id="my-dialog-title">
-            Save Your Progress
-          </h2>
-          <div class="mdc-dialog__content" id="my-dialog-content">
-            Click the "Save Progress" button to save your progress in this challenge
-          </div>
-          <footer class="mdc-dialog__actions">
-            <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="close">
-              <span class="mdc-button__label">Cancel</span>
-            </button>
-            <button type="button" class="mdc-button mdc-dialog__button mdc-ripple-upgraded mdc-ripple-upgraded--background-focused" data-mdc-dialog-action="save-code">
-              <span class="mdc-button__label">Save Progress</span>
-            </button>
-          </footer>
-        </div>
-      </div>
-      <div class="mdc-dialog__scrim" id="save-code-scrim"></div>
-    </div>
     <div data-view="home">
       <div class="mdc-layout-grid">
         <div class="mdc-layout-grid__inner">

--- a/src/playground/js/index.js
+++ b/src/playground/js/index.js
@@ -1,4 +1,5 @@
 import * as firebase from 'firebase/app';
+import dotenv from 'dotenv';
 
 import {
   trim,
@@ -21,6 +22,8 @@ let GARelay;
 let appUser;
 let provider;
 let uiIsBuilt = false;
+
+dotenv.config();
 
 const invalidURLMsg = 'Awwww Snaaap :( Your Assesment URL Is Invalid.';
 const testNotYetOpenMsg = `I see you're an early bird. However, this assessment is not yet open.`;
@@ -201,8 +204,14 @@ const takeOff = async () => {
     setupAuthentication();
 
     if(navigator.serviceWorker) {
-      const swURL = `${window.location.origin}/sw.js`;
-      navigator.serviceWorker.register(swURL);
+      if(process.env.NODE_ENV === 'development') {
+        navigator.serviceWorker.getRegistrations().then((registrations) => {
+          registrations.forEach(registration => registration.unregister());
+        });
+      } else {
+        const swURL = `${window.location.origin}/sw.js`;
+        navigator.serviceWorker.register(swURL);
+      }
     }
   }
 };

--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -446,6 +446,32 @@ const setAssessmentProgress = async () => {
   }};
 }
 
+/**
+ * @description checks whether the user has made changes to the code.
+ */
+const codeHasChanged = () => {
+  const currentCode = getCode();
+  return lastSavedCode !== currentCode;
+};
+
+/**
+ * @description Saves the codes from the editor
+ */
+const saveCode = () => {
+  if(codeHasChanged()){
+    const code = getCode();
+    if (!code) return;
+
+    notify('Saving Your Code...');
+    saveWork({
+      challengeIndex: assessmentProgress.challengeIndex,
+      completedChallenge: assessmentProgress.completedChallenge
+    });
+    lastSavedCode = code;
+    rAF({ wait: 2000 }).then(() => notify('Your code has been saved!'));
+  }
+};
+
 const setTheStage = async (challengeIndex, started) => {
   localStorage.setItem('challengeIndex', challengeIndex);
   notify('building your playground ...');
@@ -592,32 +618,6 @@ const handleSandboxMessages = async (event) => {
   }
 
   switchPreviewToEmulator();
-};
-
-/**
- * @description checks whether the user has made changes to the code.
- */
-const codeChanges = () => {
-  const currentCode = getCode();
-  return lastSavedCode !== currentCode;
-};
-
-/**
- * @description Saves the codes from the editor
- */
-const saveCode = () => {
-  if(codeChanges()){
-    const code = getCode();
-    if (!code) return;
-
-    notify('Saving Your Code...');
-    saveWork({
-      challengeIndex: assessmentProgress.challengeIndex,
-      completedChallenge: assessmentProgress.completedChallenge
-    });
-    lastSavedCode = code;
-    rAF({ wait: 2000 }).then(() => notify('Your code has been saved!'));
-  }
 };
 
 const handleSpecialKeyCombinations = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,6 +2234,11 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
+  integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==
+
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
#### What does this PR do?
Add the feature that enables saving codes on the playground

#### Description of Task to be completed
- add the save-code dialog to the html file
- add the event listener for when user leaves the page
- add the function for saving the code
- add a function that checks whether the user has made changes

#### How should this be manually tested?
- Switch to the branch `ft-enable-candidate-to-save-codes-167421868`
- start the server using `yarn develop-playground`
- work on the challenge and attempt to move go away from the window

> NB: This is best tested in the incognito mode

#### Any background context you want to provide?
Currently, users lose their code changes from the playground when they reload the browser, shift tabs or close the browser.

#### What are the relevant pivotal tracker stories?
[#167421868](https://www.pivotaltracker.com/story/show/167421868)

#### Screenshots (if appropriate)
<img width="1430" alt="Screenshot 2019-07-25 at 12 35 11 PM" src="https://user-images.githubusercontent.com/31534129/61867991-ba1ad380-aed8-11e9-9188-e9656a11203a.png">
