### PR TITLE
#167433668 move from browser time to server time

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6,9 +6,9 @@ admin.initializeApp();
 
 // firebase function to get current server timestamp
 exports.getServerTime = functions.https.onRequest((request, response ) => {
-    return cors(request, response, () => {
-        const serverTime = Date.now();
-        return response.send({time: serverTime});
-    });
+    cors(request, response, () => {
+        const serverTime = Date.now()
+        response.send({time: serverTime});
+    })
 });
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "chartjs-plugin-colorschemes": "^0.3.0",
     "chartjs-plugin-datalabels": "^0.6.0",
     "chartjs-plugin-doughnutlabel": "^2.0.3",
+    "codemirror": "^5.42.2",
     "dotenv": "^8.0.0",
     "firebase": "^6.2.4",
     "first-input-delay": "^0.1.3",

--- a/src/commons/js/getServerTime.js
+++ b/src/commons/js/getServerTime.js
@@ -8,7 +8,8 @@ const getServerTime = async () => {
         const response = await fetch(process.env.firebaseURL);
         const { time } = await response.json();
         return time;
-    } catch (error) {
+    }
+    catch(error){
         console.warn(error);
         return undefined;
     }

--- a/src/commons/js/utils.js
+++ b/src/commons/js/utils.js
@@ -165,14 +165,14 @@ const dateToUTCTime = (d) => Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()
 
 export const isAfterKickoffTime = (args) => {
   const { startingAt } = args;
-  const when = dateToUTCTime(new Date(global.serverTime));
+  const when = dateToUTCTime(new Date(serverTime));
   const limit = dateToUTCTime( new Date(`${startingAt}`) );
   return when >= limit;
 };
 
 export const isWithinDeadline = (args) => {
   const { endingAt } = args;
-  const when = dateToUTCTime( new Date(global.serverTime) );
+  const when = dateToUTCTime( new Date(serverTime) );
   const limit = dateToUTCTime( new Date(`${endingAt}`) );
   return when <= limit;
 };
@@ -187,7 +187,7 @@ const timeUnits = {
 export const dateTimeDiff = (args = {}) => {
   const { to = Date.now(), type = "hour" } = args;
   const toTime = typeof to === "number" ? to : to.getTime();
-  const diff = Math.floor(toTime - global.serverTime) / timeUnits[type];
+  const diff = Math.floor(toTime - serverTime) / timeUnits[type];
   return Math.round(diff);
 };
 

--- a/src/commons/js/utils.js
+++ b/src/commons/js/utils.js
@@ -165,14 +165,14 @@ const dateToUTCTime = (d) => Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()
 
 export const isAfterKickoffTime = (args) => {
   const { startingAt } = args;
-  const when = dateToUTCTime(new Date(serverTime));
+  const when = dateToUTCTime(new Date(global.serverTime));
   const limit = dateToUTCTime( new Date(`${startingAt}`) );
   return when >= limit;
 };
 
 export const isWithinDeadline = (args) => {
   const { endingAt } = args;
-  const when = dateToUTCTime( new Date(serverTime) );
+  const when = dateToUTCTime( new Date(global.serverTime) );
   const limit = dateToUTCTime( new Date(`${endingAt}`) );
   return when <= limit;
 };
@@ -187,7 +187,7 @@ const timeUnits = {
 export const dateTimeDiff = (args = {}) => {
   const { to = Date.now(), type = "hour" } = args;
   const toTime = typeof to === "number" ? to : to.getTime();
-  const diff = Math.floor(toTime - serverTime) / timeUnits[type];
+  const diff = Math.floor(toTime - global.serverTime) / timeUnits[type];
   return Math.round(diff);
 };
 

--- a/src/playground/js/index.js
+++ b/src/playground/js/index.js
@@ -175,9 +175,13 @@ const setupAuthentication = () => {
 };
 
 const takeOff = async () => {
-  // set the serverTime after every 3 seconds
-  global.serverTime = await getServerTime()
-  setInterval(async() => {global.serverTime += 3000}, 3000);
+  // get the serverTime right now and 
+  // uodate it after every 1 hour
+  global.serverTime = await getServerTime();
+  const serverPingInterval = 1000 * 60 * 60;
+  rAF({wait: serverPingInterval}).then(async () => {
+    global.serverTime = await getServerTime();
+  });
 
   importGARelay().then(module => {
     GARelay = module.default;
@@ -222,12 +226,6 @@ const takeOff = async () => {
         navigator.serviceWorker.register(swURL);
       }
     }
-
-    // set the serverTime after every 1 hour
-    // const serverPingInterval = 1000 * 60 * 60;
-    // rAF({wait: serverPingInterval}).then(async () => {
-    //   global.serverTime = await getServerTime();
-    // });
   }
 };
 

--- a/src/playground/js/index.js
+++ b/src/playground/js/index.js
@@ -175,7 +175,9 @@ const setupAuthentication = () => {
 };
 
 const takeOff = async () => {
-  global.serverTime = await getServerTime();
+  // set the serverTime after every 3 seconds
+  global.serverTime = await getServerTime()
+  setInterval(async() => {global.serverTime += 3000}, 3000);
 
   importGARelay().then(module => {
     GARelay = module.default;


### PR DESCRIPTION
#### What does this PR do?
- Move assessment timer from browser time to server time
- Prevent users from submitting a test after deadline
- Prevent timer from locking out users before the deadline(timezone)

#### Description of Task to be completed
- Add a firebase function to get the current time of the server at an instance
- Ensure that timezones are observed

#### How should this be manually tested?
- To test that the application does not allow a user to submit after the deadline:
        - Checkout to this branch `ft-move-assessment-timer-167208531`
        - Start the server and navigate to this URL : ```http://localhost:1234/jqe3zYO8xTfiuCLDEEgu/!#playground```
       -  Change your computer time to last year and try to run the code
       -  The deadline remains the same 
- To test that the application does not lockout a user before the deadline:
    - Use a VPN to change your location
    - The deadline to completion of the test should remain the same
 
#### Any background context you want to provide?
`N/A`

#### What are the relevant pivotal tracker stories?
[#167433668](https://www.pivotaltracker.com/story/show/167433668)
[#167341077](https://www.pivotaltracker.com/story/show/167341077)
[#167208531](https://www.pivotaltracker.com/story/show/167208531)

#### Screenshots (if appropriate)
`N/A`
