### PR TITLE
#167232609 Playground instructions should open all links in a new browser tab

### DIFF
--- a/src/playground/css/main.scss
+++ b/src/playground/css/main.scss
@@ -232,6 +232,7 @@ body[data-assessment] #instructions [data-challenge-info-wrap] {
   margin-top: -62px;
   height: calc(100vh - 120px);
   font-family: Roboto,sans-serif;
+  word-break: break-word;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   font-size: 1rem;

--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -242,17 +242,16 @@ const navigateToChallengeInstructions = async (challengeIndex) => {
   if(challengeInfo) {
     const renderer = new marked.Renderer();
     renderer.link = (href, title, text) => {
-      let link = `<a href="${href}" title="${title}">${text}</a>`;
-      if(/http|www/.test(href)) {
-        link = link.replace(/a href/, 'a target="_blank" href')
-      }
-      return link
+      const normalisedTitle = title === null ? 'external resource' : title;
+      let target = '';
+      if(/http|www/.test(href)) target = `target="_blank"`;
+      return `<a href="${href}" title="${normalisedTitle}" ${target}>${text}</a>`;
     }
 
     challengeInfo.innerHTML = marked(intructions, {
       gfm: true,
-      smartLists: true,
-      renderer
+      renderer,
+      smartLists: true
     });
   }
 

--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -240,9 +240,19 @@ const safelyIncrementChallengeIndex = (challengeLength, challengeIndex) => {
 const navigateToChallengeInstructions = async (challengeIndex) => {
   const intructions = await setupInstructions(challengeIndex);
   if(challengeInfo) {
+    const renderer = new marked.Renderer();
+    renderer.link = (href, title, text) => {
+      let link = `<a href="${href}" title="${title}">${text}</a>`;
+      if(/http|www/.test(href)) {
+        link = link.replace(/a href/, 'a target="_blank" href')
+      }
+      return link
+    }
+
     challengeInfo.innerHTML = marked(intructions, {
       gfm: true,
-      smartLists: true
+      smartLists: true,
+      renderer
     });
   }
 


### PR DESCRIPTION
#### What does this PR do?
- parse instructions HTML string and add target attribute set to `_blank` to <a> elements

#### Description of Task to be completed
- A user should be able to open the links for the playground instructions in a new browser tab; given a user clicks on the link for the playground instruction then it should open in a new browser tab

#### How should this be manually tested?
- switch to the branch `ft-playground-instructions-167232609`
- start the server using `yarn develop-playground`
- use the URL `http://localhost:1234/jqe3zYO8xTfiuCLDEEgu` on the browser to load an assessment.
- Click on any link in the instructions and it should open in a separate tab

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#167232609 Playground instructions should open all links in a new browser tab](https://www.pivotaltracker.com/story/show/167232609)

#### Screenshots (if appropriate)
- N/A