### PR TITLE
#167564793 Disable code saving after assessment deadline

### DIFF
--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -480,20 +480,34 @@ const saveWorkBatched = async () => {
   assessmentProgress = { ...assessmentProgress, ...performance };
 };
 
+/**
+ * @description handles the saving of users progress
+ * if the changes on the challenge is before the specified deadline
+ * 
+ * @param {object} assessment progress 
+ */
 const saveWork = ({completedChallenge, challengeIndex}) => {
-  if(batchedProgress.length === 0) {
-    // TODO queue this with promises instead
-    // right now, we have no way of knowing 
-    // that the save operation is done or if it failed
-    rAF({wait: 5000})
-    .then(() => {
-      saveWorkBatched();
-    });
+  const { endingAt } = assessment;
+  if(isWithinDeadline({ endingAt })){
+    notify('Saving Your Code...');
+    if(batchedProgress.length === 0) {
+      // TODO queue this with promises instead
+      // right now, we have no way of knowing 
+      // that the save operation is done or if it failed
+      rAF({wait: 5000})
+      .then(() => {
+        saveWorkBatched();
+      });
+    }
+
+    if (savingBatchedProgress === true) return;
+
+    batchedProgress.push({ completedChallenge, challengeIndex });
+
+    notify('Your changes have been saved');
+  } else {
+    notify(testOverMsg);
   }
-
-  if (savingBatchedProgress === true) return;
-
-  batchedProgress.push({ completedChallenge, challengeIndex });
 };
 
 /**
@@ -521,7 +535,8 @@ const codeHasChanged = () => {
  * @description Saves the codes from the editor
  */
 const saveCode = () => {
-  if(codeHasChanged()){
+  const { endingAt } = assessment;
+  if(codeHasChanged() && isWithinDeadline({ endingAt })){
     const code = getCode();
     if (!code) return;
 


### PR DESCRIPTION
#### What does this PR do?
Disable code saving when assessment after the deadline

#### Description of Task to be completed
- add a check that disables code saving after the assessment deadline

#### How should this be manually tested?
- Switch to the branch `ft-save-code-only-before-deadline-167564793`
- start the server using `yarn develop-playground`
- work on the challenge and attempt to move go away from the window
- attempt working on a challenge with an expired deadline

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#167564793](https://www.pivotaltracker.com/story/show/167564793)

#### Screenshots (if appropriate)
N/A