### PR TITLE
chore(github-auth): Relax Github authentication permissions

### DIFF
--- a/src/dash/js/index.js
+++ b/src/dash/js/index.js
@@ -37,7 +37,6 @@ const takeOff = () => {
 
     // TODO switch to email/password  provider
     provider = new firebase.auth.GithubAuthProvider();
-    provider.addScope('repo');
     provider.setCustomParameters({
       allow_signup: 'false'
     });

--- a/src/playground/js/index.js
+++ b/src/playground/js/index.js
@@ -149,7 +149,6 @@ const bootstrapAssessment = async user => {
 
 const setupAuthentication = () => {
   provider = new firebase.auth.GithubAuthProvider();
-  provider.addScope('repo');
   provider.setCustomParameters({
     allow_signup: 'false'
   });


### PR DESCRIPTION
#### What does this PR do?
- remove GitHub repo scope from authentication

#### Description of Task to be completed
- A user should be able to log in using `GITHUB authentication` without allowing Gradr application  asking  access to the user repositories

#### How should this be manually tested?
- switch to the branch `ch-github-permissions-167564733`
- use a new GitHub account to access the assessment `http://localhost:1234/jqe3zYO8xTfiuCLDEEgu/`

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
[#167564733 Relax Github authentication permissions](https://www.pivotaltracker.com/story/show/167564733)

#### Screenshots (if appropriate)
**Before**
![image](https://user-images.githubusercontent.com/28973383/62052574-071ee280-b216-11e9-9e54-665969fdfb0e.png)
**After**
![image](https://user-images.githubusercontent.com/28973383/62052601-143bd180-b216-11e9-961f-05e6d24197c3.png)
