### PR TITLE
ft(notifications): Improve Playground feedback notification UI/UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,10 @@
     "monaco-dev-build": "parcel build node_modules/monaco-editor/esm/vs/language/**/*.worker.js node_modules/monaco-editor/esm/vs/editor/**/*.worker.js --out-dir dev-build --no-source-maps",
     "monaco-playground-build": "parcel build node_modules/monaco-editor/esm/vs/language/**/*.worker.js node_modules/monaco-editor/esm/vs/editor/**/*.worker.js --out-dir dist/playground --no-source-maps",
     "monaco-admin-build": "parcel build node_modules/monaco-editor/esm/vs/language/**/*.worker.js node_modules/monaco-editor/esm/vs/editor/**/*.worker.js --out-dir dist/admin --no-source-maps",
-
     "develop-playground": "yarn monaco-dev-build && parcel src/playground/index.html --out-dir dev-build",
     "develop-admin": "yarn monaco-dev-build && parcel src/dash/index.html --out-dir dev-build",
-
     "build-playground": "yarn monaco-playground-build && parcel build src/playground/index.html --out-dir dist/playground --no-source-maps",
     "build-admin": "yarn monaco-admin-build && parcel build src/dash/index.html --out-dir dist/admin --no-source-maps",
-
     "deploy-admin": "firebase deploy --only hosting:admin",
     "deploy-playground": "minify dist/playground/mygradr -d dist/playground/mygradr && firebase deploy --only hosting:playground"
   },
@@ -64,6 +61,7 @@
     "lit-html": "^1.0.0",
     "marked": "0.6.3",
     "mo": "^1.7.3",
-    "monaco-editor": "0.17.1"
+    "monaco-editor": "0.17.1",
+    "toastr": "^2.1.4"
   }
 }

--- a/src/playground/css/main.scss
+++ b/src/playground/css/main.scss
@@ -357,15 +357,22 @@ body[data-nav='playground'] #launcher-svg-container.km-chat-icon-sidebox img {
 }
 /* End Playground */
 
-body[data-nav='playground'] .mdc-snackbar.mdc-snackbar--open,
-body[data-nav='playground'] .mdc-snackbar.mdc-snackbar--closing {
-  position: fixed;
-  top: -5px;
-  left: 0;
-  right: 0;
-  bottom: auto;
-}
-
 body[data-nav='playground'] .mdc-snackbar.mdc-snackbar--open .mdc-snackbar__label {
   font-size: 110%;
+}
+
+#toast-container {
+  // width: 300px;
+  .toast-message {
+    color: #000;
+  }
+}
+#toast-container>.toast-info {
+  background-color: #000;
+  margin-left: 20% !important;
+  width: 30% !important;
+
+}
+.toast-message {
+  color: #000;
 }

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -19,6 +19,7 @@
 
   <link rel="stylesheet" href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css">
   <link rel="stylesheet" href="./css/main.scss" />
+  <link href="//cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css" rel="stylesheet" />
 
   <!-- FID Monitor Core -->
   <script>
@@ -65,7 +66,7 @@
     </div>
   </div>
 
-  <div class="mdc-snackbar mdc-snackbar--stacked" id="intro-toast">
+  <div class="mdc-snackbar mdc-snackbar--baseline" id="intro-toast">
     <div class="mdc-snackbar__surface">
       <div class="mdc-snackbar__label" role="status" aria-live="polite"></div>
     </div>
@@ -92,9 +93,10 @@
     </div>
 
     <div data-view="playground">
-      <div class="mdc-snackbar mdc-snackbar--stacked" id="toast">
+      <div class="mdc-snackbar mdc-snackbar--baseline" id="toast">
         <div class="mdc-snackbar__surface">
-          <div class="mdc-snackbar__label" role="status" aria-live="polite"></div>
+          <div class="mdc-snackbar__label" role="status" aria-live="polite">
+          </div>
         </div>
       </div>
 

--- a/src/playground/js/index.js
+++ b/src/playground/js/index.js
@@ -32,7 +32,7 @@ const testNotYetOpenMsg = `I see you're an early bird. However, this assessment 
 
 const notify = msg => {
   if (!toast || trim(msg) === '') return;
-
+  toast = mdc.snackbar.MDCSnackbar.attachTo(select('#intro-toast'));
   select('#intro-toast .mdc-snackbar__label').textContent = msg;
   toast.open();
 };
@@ -43,7 +43,7 @@ const signIn = () => {
   firebase
     .auth()
     .signInWithPopup(provider)
-    .catch(error => {
+    .catch(error => {      
       const { code, message } = error;
       if (code && code.indexOf('account-exists-with-different-credential') !== -1) {
         notify(
@@ -183,7 +183,6 @@ const takeOff = async () => {
   });
 
   handleWindowPopState();
-  toast = mdc.snackbar.MDCSnackbar.attachTo(select('#intro-toast'));
   const { pathname } = window.location;
 
   if (pathname === '/' || pathname === '/!') {

--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -39,22 +39,47 @@ const SUBMISSIONS = firebase.firestore().collection('submissions');
 
 const challengeInfo = select('[data-challenge-info]');
 const testOverMsg = 'This assessment is closed. Your changes will not be saved or evaluated';
+const toastr = require('toastr')
 
-const notify = (msg) => {
+const notifyBuild = (msg) => {
   let message = trim(msg);
-  if (message === '') return;
-
-  if (message === 'ERROR') {
+  if(message === 'ERROR') {
     message = `You've Got One Or More Syntax Errors In Your Code!`;
   }
+  if (message === '') return;
+  const toastElement = select('#toast');
+  if (!toast) toast = mdc.snackbar.MDCSnackbar.attachTo(toastElement);
+  toastElement.querySelector('.mdc-snackbar__label').textContent = message;
+  toast.setTimeoutMs = 0 
+  toast.timeoutMs = 4000;
 
-  const toastr = select('#toast');
-  if (!toast) toast = mdc.snackbar.MDCSnackbar.attachTo(toastr);
-  // toast.close();
+  toast.open(true);
+  
 
-  toastr.querySelector('.mdc-snackbar__label').textContent = message;
-  toast.timeoutMs = 10000;
-  toast.open();
+}
+const notify = (msg) => {
+  const message = trim(msg);
+  if (message === '') return;
+  toastr.remove()
+  toastr.options = {
+    "closeButton": true,
+    "debug": false,
+    "newestOnTop": false,
+    "progressBar": false,
+    "positionClass": "toast-top-full-width",
+    "preventOpenDuplicates": true,
+    "onclick": null,
+    "showDuration": "300",
+    "hideDuration": "1000",
+    "timeOut": "0",
+    "extendedTimeOut": "0",
+    "showEasing": "swing",
+    "hideEasing": "linear",
+    "showMethod": "fadeIn",
+    "hideMethod": "fadeOut",
+    "setCloseOnEscape": false
+  }
+  toastr.info('message', message)
 };
 
 const signOut = event => {
@@ -401,7 +426,7 @@ const challengeIntro = async () => {
 };
 
 const playCode = () => {
-  const challengeIndex = parseInt(localStorage.getItem('challengeIndex'), 10);
+  const challengeIndex = parseInt(localStorage.getItem('challengeIndex'), 10);  
   if (challengeIndex < 0) {
     initProject();
   }
@@ -409,7 +434,8 @@ const playCode = () => {
   const code = getCode();
   if (!code) return;
 
-  notify('Lets Run Your Code ...');
+  // Removed this for the mean time
+  // notifyBuild('Lets Run Your Code ...');
 
   prepareEmulatorPreview();
   const payload = extractCode(code);
@@ -521,7 +547,7 @@ const saveCode = () => {
 
 const setTheStage = async (challengeIndex, started) => {
   localStorage.setItem('challengeIndex', challengeIndex);
-  notify('building your playground ...');
+  notifyBuild('building your playground ...');
 
   mdc.topAppBar.MDCTopAppBar.attachTo(select('.mdc-top-app-bar'));
   setupAccount();
@@ -565,7 +591,7 @@ const setTheStage = async (challengeIndex, started) => {
     }
   });
 
-  notify('building your auto-grader ...');
+  notifyBuild('building your auto-grader ...');
 
   const sandbox = select('#sandbox');
   const viewer = select('#viewer');
@@ -581,7 +607,7 @@ const setTheStage = async (challengeIndex, started) => {
   document.body.addEventListener('mouseleave', saveCode);
   window.addEventListener('beforeunload', saveCode);
 
-  notify('DONE!');
+  notifyBuild('DONE!');
   return { codeEditor, sandbox, viewer };
 };
 
@@ -703,7 +729,7 @@ const deferredEnter = async (args) => {
 };
 
 export const enter = async (args = {}) => {
-  notify('Building your playground, please wait ...');
-  deferredEnter(args);
+  notifyBuild('Building your playground, please wait ...');
+  deferredEnter(args); 
 };
 export default { enter };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3073,6 +3073,11 @@ isomorphic-fetch@2.2.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
+jquery@>=1.12.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
+
 js-levenshtein@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -4805,6 +4810,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toastr@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/toastr/-/toastr-2.1.4.tgz#8b43be64fb9d0c414871446f2db8e8ca4e95f181"
+  integrity sha1-i0O+ZPudDEFIcURvLbjoyk6V8YE=
+  dependencies:
+    jquery ">=1.12.0"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
#### What does this PR do?
- Improve Playground feedback notification UI/UX

#### Description of Task to be completed
- Add a toastr to display user feedback
- Maintain a snack bar for displaying build feedback
- Remove snack bar CSS which was holding the snack bar to the top of the page

#### How should this be manually tested?
 - Switch to the branch `ft-playground-notifications-167004638`
- start the server using `yarn develop-playground`
- work on the challenge and run your code
- Feedback will be displayed in the toastr modal and will only disappear when you cancel from the toastr modal.
- Build feedback will display at the bottom of the page.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#167004638](https://www.pivotaltracker.com/story/show/167004638)

#### Screenshots (if appropriate)
![Screenshot 2019-07-30 at 10 35 17](https://user-images.githubusercontent.com/32167860/62113902-cb3b5a00-b2b5-11e9-84d6-ea613c85827e.png)
