### PR TITLE
#167564810 Reset codebase back to starter code

### DIFF
--- a/src/playground/css/main.scss
+++ b/src/playground/css/main.scss
@@ -254,13 +254,13 @@ body[data-assessment] #instructions [data-challenge-info-wrap] {
 
 #instructions.live {
   opacity: 1;
-  z-index: 1;
+  z-index: 2;
 }
 
 #viewer.live {
   opacity: 1;
   top: 35px;
-  z-index: 10;
+  z-index: 2;
 }
 
 #viewer.buffering {

--- a/src/playground/css/main.scss
+++ b/src/playground/css/main.scss
@@ -120,7 +120,7 @@ body[data-assessment] header.mdc-top-app-bar--short-collapsed button {
 
 #code-nav [data-challange-step] {
   float: left;
-  z-index: 10;
+  z-index: 1;
   font-size: 165%;
   background-color: transparent;
   color: rgba(0,0,0,.37);
@@ -254,7 +254,7 @@ body[data-assessment] #instructions [data-challenge-info-wrap] {
 
 #instructions.live {
   opacity: 1;
-  z-index: 10;
+  z-index: 1;
 }
 
 #viewer.live {
@@ -368,4 +368,16 @@ body[data-nav='playground'] .mdc-snackbar.mdc-snackbar--closing {
 
 body[data-nav='playground'] .mdc-snackbar.mdc-snackbar--open .mdc-snackbar__label {
   font-size: 110%;
+}
+
+#reset-code {
+  display: none;
+  position: absolute;
+  top: 3px;
+  margin-left: 120px;
+  color: black;
+}
+
+.mdc-dialog__surface {
+  padding: 20px;
 }

--- a/src/playground/index.html
+++ b/src/playground/index.html
@@ -39,7 +39,7 @@
         </button>
       </section>
       <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
-        <a href="#" id="runit" class="material-icons mdc-top-app-bar__action-item" aria-label="Run your code"
+        <button id="runit" class="material-icons mdc-top-app-bar__action-item mdc-icon-button" aria-label="Run your code"
           alt="Run your code">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
             <path d="M0 0h24v24H0z" fill="none" />
@@ -47,8 +47,40 @@
               fill="#fff"
               d="M10 16.5l6-4.5-6-4.5v9zM12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
             </svg>
-        </a>
+          </button>
       </section>
+    </div>
+
+    <button id="reset-code" class="mdc-icon-button" aria-label="Reset your code to the starter code"
+      aria-hidden="true" aria-pressed="true" title="Reset your code to the starter code">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>
+    </button>
+
+    <div class="mdc-dialog" data-action="reset-dialog"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="my-dialog-title"
+      aria-describedby="my-dialog-content">
+      <div class="mdc-dialog__container">
+        <div class="mdc-dialog__surface">
+          <h2 class="mdc-dialog__title" id="my-dialog-title">
+              Reset Code to Starter Code
+          </h2>
+          <div class="mdc-dialog__content" id="my-dialog-content">
+            You will lose all your progress in this challenge.
+            Are you sure you want to reset your code?
+          </div>
+          <footer class="mdc-dialog__actions">
+            <button type="button" class="mdc-button mdc-dialog__button mdc-ripple-upgraded mdc-ripple-upgraded--background-focused" data-mdc-dialog-action="close">
+              <span class="mdc-button__label">Cancel</span>
+            </button>
+            <button type="button" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="reset" data-action="reset-confirm">
+              <span class="mdc-button__label">Reset Code</span>
+            </button>
+          </footer>
+        </div>
+      </div>
+      <div class="mdc-dialog__scrim"></div>
     </div>
   </header>
 

--- a/src/playground/js/playground.js
+++ b/src/playground/js/playground.js
@@ -37,6 +37,12 @@ let lastSavedCode;
 const SPECS = firebase.firestore().collection('specs');
 const SUBMISSIONS = firebase.firestore().collection('submissions');
 
+const resetButtonIcon = select("#reset-code");
+const resetDialogComponent = select(`[data-action='reset-dialog']`);
+const cancelResetButton = select(`[data-mdc-dialog-action='close']`);
+const confirmResetButton = select(`[data-action='reset-confirm']`);
+const resetDialogScrim = select('.mdc-dialog__scrim');
+
 const challengeInfo = select('[data-challenge-info]');
 const testOverMsg = 'This assessment is closed. Your changes will not be saved or evaluated';
 
@@ -532,11 +538,38 @@ const saveCode = () => {
   }
 };
 
+const resetCodebase = () => {
+  resetDialogComponent.classList.remove('mdc-dialog--open');
+  const { starterCodebase } = spec;
+  editor.setValue(starterCodebase);
+  saveCode();
+}
+
+const closeResetDialog = () => {
+  resetDialogComponent.classList.remove('mdc-dialog--open');
+  cancelResetButton.removeEventListener('click', closeResetDialog);
+  resetDialogScrim.removeEventListener('click', closeResetDialog);
+  confirmResetButton.removeEventListener('click', resetCodebase);
+};
+
+const openResetDialog = () => {
+  const { starterCodebase } = spec;
+  const currentCodebase = editor.getValue();
+  if (!(starterCodebase === currentCodebase)) {
+    resetDialogComponent.classList.add('mdc-dialog--open');
+    cancelResetButton.addEventListener('click', closeResetDialog);
+    resetDialogScrim.addEventListener('click', closeResetDialog);
+    confirmResetButton.addEventListener('click', resetCodebase);
+  }
+};
+
 const setTheStage = async (challengeIndex, started) => {
   localStorage.setItem('challengeIndex', challengeIndex);
   notify('building your playground ...');
 
   mdc.topAppBar.MDCTopAppBar.attachTo(select('.mdc-top-app-bar'));
+  resetButtonIcon.style.display = 'block'; 
+  resetButtonIcon.addEventListener('click', openResetDialog)
   setupAccount();
 
   select('#runit').addEventListener('click', (event) => {


### PR DESCRIPTION
#### What does this PR do?
- adds a confirmation modal
- adds a method to reset code in the editor
- saves the reset code

#### Description of Task to be completed
- A user should be able to reset his codebase back to the previous status in case he or she messes up his work. Given I mess up my code then I should be able to undo back to the previous state of code.

#### How should this be manually tested?
- switch to the branch `ft-reset-codebase-to-starter-167564810`
- start the server using `yarn develop-playground` and use the assessment `http://localhost:1234/jqe3zYO8xTfiuCLDEEgu/`
- Edit code in the editor and then click on the reset icon.
- Code should be reset to the starter code

#### Any background context you want to provide?
- If the code is similar to the starter code, you won't be able to reset it

#### What are the relevant pivotal tracker stories?
[#167564810 Reset codebase back to starter code](https://www.pivotaltracker.com/story/show/167564810)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/28973383/62193825-e327e200-b378-11e9-9fae-7152041b22e9.png)
![image](https://user-images.githubusercontent.com/28973383/62193845-ea4ef000-b378-11e9-947d-af1c92ca85a0.png)
![image](https://user-images.githubusercontent.com/28973383/62193852-ef13a400-b378-11e9-80ac-bf7c7e4f58c5.png)
![image](https://user-images.githubusercontent.com/28973383/62193872-f935a280-b378-11e9-8291-31ad1fe4a188.png)
